### PR TITLE
Fix createIndex and ensureIndex

### DIFF
--- a/models.js
+++ b/models.js
@@ -121,6 +121,7 @@ dbModel.prototype = {
     })
   },
   createIndex: function(indexName) {
+    var fields = this.indexes[indexName] || indexName
     return this.kninky.k.schema.alterTable(this.tableName, function(table) {
       table.index(fields)
     }).then(function passed() {


### PR DESCRIPTION
Before this fix these functions were silently failing to create indexes because `fields` was undefined. 